### PR TITLE
add checks to prevent closed tabs from throwing exceptions

### DIFF
--- a/modules/spin-tools/src/com/maccasoft/propeller/EditorTab.java
+++ b/modules/spin-tools/src/com/maccasoft/propeller/EditorTab.java
@@ -494,7 +494,7 @@ public class EditorTab implements FindReplaceTarget {
 
                     @Override
                     public void run() {
-                        if (outlineView != null && !outlineView.getControl().isDisposed()) {
+                        if (outlineView != null && !outlineView.getControl().isDisposed() && root != null) {
                             outlineView.setInput(root);
                         }
                     }
@@ -575,7 +575,7 @@ public class EditorTab implements FindReplaceTarget {
 
                                     @Override
                                     public void run() {
-                                        if (editor == null || editor.getStyledText().isDisposed()) {
+                                        if (editor == null || tabItem.isDisposed() || editor.getStyledText().isDisposed()) {
                                             return;
                                         }
                                         changeSupport.firePropertyChange(OBJECT_TREE, null, objectTree);


### PR DESCRIPTION
Mitigates the issue that exceptions are thrown when tabs actively compiling are closed, then attempt to update the disposed UI elements. Alternatively, not implemented, would be a graceful stop of the compiling process.

This is easily triggered using the Close All Tabs command. See issue #3 for details.

### Issues this Resolves:
Resolves #3 